### PR TITLE
fix the plt.clabel() error

### DIFF
--- a/chapter9/plt_contour.py
+++ b/chapter9/plt_contour.py
@@ -21,7 +21,7 @@ im = plt.imshow(z, interpolation='bilinear', origin='lower',
                 cmap=cm.gray, extent=(-3, 3, -2, 2))
 
 # (2) 등고선 표시
-levels = np.arange(-3, 2.5, 0.5)
+levels = np.arange(-2.5, 2.5, 0.5)
 ctr = plt.contour(z, levels, colors='k', origin='lower',
                   linewidths=2, extent=(-3, 3, -2, 2))
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/yklyu/scTechPython/chapter9/plt_contour.py", line 30, in <module>
    fmt='%1.1f', fontsize=14)
  File "/home/yklyu/.pyenv/versions/anaconda3-5.1.0/lib/python3.6/site-packages/matplotlib/pyplot.py", line 2776, in clabel
    ret = ax.clabel(CS, *args, **kwargs)
  File "/home/yklyu/.pyenv/versions/anaconda3-5.1.0/lib/python3.6/site-packages/matplotlib/axes/_axes.py", line 5833, in clabel
    return CS.clabel(*args, **kwargs)
  File "/home/yklyu/.pyenv/versions/anaconda3-5.1.0/lib/python3.6/site-packages/matplotlib/contour.py", line 176, in clabel
    raise ValueError(msg)
ValueError: Specified levels [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0]
 don't match available levels [-2.5 -2.  -1.5 -1.  -0.5  0.   0.5  1.   1.5  2. ]